### PR TITLE
Various improvments and non-nginx ingress support

### DIFF
--- a/components/kommonitor/client-config/deployment.yaml
+++ b/components/kommonitor/client-config/deployment.yaml
@@ -16,12 +16,12 @@ spec:
     spec:
       containers:
       - name: kommonitor-client-config
-        image: kommonitor/client-config
+        image: kommonitor/client-config:2.0.4
         imagePullPolicy: Always
         resources:
           requests:
-            memory: "16M"
-            cpu: "1m"
+            memory: "64M"
+            cpu: "10m"
           limits:
             memory: "1024M"
             cpu: "1000m"

--- a/components/kommonitor/client-config/secret.yaml
+++ b/components/kommonitor/client-config/secret.yaml
@@ -5,4 +5,5 @@ metadata:
 type: Opaque
 data:
   # Default values. Change it!
+  # Base64 encoded
   keycloak.secret: c2VjcmV0

--- a/components/kommonitor/data-management/deployment.yaml
+++ b/components/kommonitor/data-management/deployment.yaml
@@ -16,12 +16,12 @@ spec:
     spec:
       containers:
       - name: kommonitor-data-management
-        image: kommonitor/data-management
+        image: kommonitor/data-management:4.0.1
         imagePullPolicy: Always
         resources:
           requests:
-            memory: "16M"
-            cpu: "1m"
+            memory: "300M"
+            cpu: "10m"
           limits:
             memory: "1024M"
             cpu: "1000m"

--- a/components/kommonitor/data-management/secret.yaml
+++ b/components/kommonitor/data-management/secret.yaml
@@ -5,4 +5,5 @@ metadata:
 type: Opaque
 data:
   # Default values. Change it!
+  # Base64 encoded
   keycloak.secret: c2VjcmV0

--- a/components/kommonitor/importer/deployment.yaml
+++ b/components/kommonitor/importer/deployment.yaml
@@ -16,12 +16,12 @@ spec:
     spec:
       containers:
       - name: kommonitor-importer
-        image: kommonitor/importer
+        image: kommonitor/importer:3.2.4
         imagePullPolicy: Always
         resources:
           requests:
-            memory: "16M"
-            cpu: "1m"
+            memory: "192M"
+            cpu: "10m"
           limits:
             memory: "1024M"
             cpu: "1000m"

--- a/components/kommonitor/nginx-rewrite/configmap.yaml
+++ b/components/kommonitor/nginx-rewrite/configmap.yaml
@@ -1,3 +1,5 @@
+# Use only for non-nginx ingress!
+#
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/components/kommonitor/nginx-rewrite/configmap.yaml
+++ b/components/kommonitor/nginx-rewrite/configmap.yaml
@@ -1,0 +1,65 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kommonitor-nginx
+data:
+  nginx.conf: |
+    user  nginx;
+    worker_processes  auto;
+
+    error_log  /var/log/nginx/error.log notice;
+    pid        /var/run/nginx.pid;
+
+
+    events {
+        worker_connections  1024;
+    }
+
+
+    http {
+        include       /etc/nginx/mime.types;
+        default_type  application/octet-stream;
+
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+        access_log  /var/log/nginx/access.log  main;
+
+        sendfile        on;
+        #tcp_nopush     on;
+
+        keepalive_timeout  65;
+
+        #gzip  on;
+
+        #include /etc/nginx/conf.d/*.conf;
+
+        server {
+          listen 80;
+
+          location /ui/ {
+            proxy_pass http://kommonitor-web-client:80/;
+          }
+          location /data-management/ {
+            proxy_pass http://kommonitor-data-management:8085/;
+          }
+          location /data-importer/ {
+            proxy_pass http://kommonitor-importer:8087/;
+          }
+          location /client-config/ {
+            proxy_pass http://kommonitor-client-config:8088/;
+          }
+          location /data-processing/ {
+            proxy_pass http://kommonitor-processing-engine:8086/;
+          }
+          location /spatial-processor/ {
+            proxy_pass http://kommonitor-spatial-data-processor:8090/;
+          }
+          location / {
+            # rewrite ^/$ /ui/ redirect;
+            return 301 http://$host/ui/;
+          }
+        }
+
+    }

--- a/components/kommonitor/nginx-rewrite/deployment.yaml
+++ b/components/kommonitor/nginx-rewrite/deployment.yaml
@@ -1,3 +1,5 @@
+# Use only for non-nginx ingress!
+#
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/components/kommonitor/nginx-rewrite/deployment.yaml
+++ b/components/kommonitor/nginx-rewrite/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kommonitor-nginx
+  labels:
+    app: kommonitor-nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kommonitor-nginx
+  template:
+    metadata:
+      labels:
+        app: kommonitor-nginx
+    spec:
+      containers:
+      - name: kommonitor-nginx
+        image:  nginx:1.27.1
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: "64M"
+            cpu: "10m"
+          limits:
+            memory: "1024M"
+            cpu: "1000m"
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: kommonitor-nginx
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+      volumes:
+      - name: kommonitor-nginx
+        configMap:
+          name: kommonitor-nginx

--- a/components/kommonitor/nginx-rewrite/service.yaml
+++ b/components/kommonitor/nginx-rewrite/service.yaml
@@ -1,3 +1,5 @@
+# Use only for non-nginx ingress!
+#
 apiVersion: v1
 kind: Service
 metadata:

--- a/components/kommonitor/nginx-rewrite/service.yaml
+++ b/components/kommonitor/nginx-rewrite/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kommonitor-nginx
+  labels:
+    app: kommonitor-nginx
+spec:
+  selector:
+    app: kommonitor-nginx
+  ports:
+  - name: "http"
+    port: 80
+    targetPort: 80

--- a/components/kommonitor/processing-engine/configmap.yaml
+++ b/components/kommonitor/processing-engine/configmap.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: kommonitor-processing-engine
 data:
-  ###### ###############
+  #####################
   #      General      #
   #####################
   # use kubernetes service name if possible; else IP 

--- a/components/kommonitor/processing-engine/deployment.yaml
+++ b/components/kommonitor/processing-engine/deployment.yaml
@@ -16,11 +16,11 @@ spec:
     spec:
       containers:
       - name: kommonitor-processing-engine
-        image: kommonitor/processing-engine
+        image: kommonitor/processing-engine:2.0.2
         imagePullPolicy: Always
         resources:
           requests:
-            memory: "16M"
+            memory: "96M"
             cpu: "1m"
           limits:
             memory: "1024M"

--- a/components/kommonitor/processing-engine/secret.yaml
+++ b/components/kommonitor/processing-engine/secret.yaml
@@ -5,6 +5,7 @@ metadata:
 type: Opaque
 data:
   # Default values. Change it!
+  # Base64 encoded
   keycloak.secret: c2VjcmV0
   admin.username: cHJvY2Vzc29y
   admin.password: cHJvY2Vzc29y

--- a/components/kommonitor/processing-scheduler/configmap.yaml
+++ b/components/kommonitor/processing-scheduler/configmap.yaml
@@ -12,7 +12,7 @@ data:
   KOMMONITOR_PROCESSING_ENGINE_URL: http://kommonitor-processing-engine:8086/processing
   # CRON pattern (refer to https://www.npmjs.com/package/node-cron) for periodic scheduler triggering
   # to initialize missing indicator time-series elements  
-  CRON_PATTERN_FOR_SCHEDULING: "* * * * *"
+  CRON_PATTERN_FOR_SCHEDULING: "*/5 * * * *"
   # default false; global setting whether the computed indictor values from the hierarchically lowest
   # spatial unit shall be aggregated to hierarchically higher spatial units (true) or if each spatial
   # unit shall be computed own their own (false - required that base data is available on the respective spatial units)

--- a/components/kommonitor/processing-scheduler/deployment.yaml
+++ b/components/kommonitor/processing-scheduler/deployment.yaml
@@ -16,12 +16,12 @@ spec:
     spec:
       containers:
       - name: kommonitor-processing-scheduler
-        image: kommonitor/processing-scheduler
+        image: kommonitor/processing-scheduler:2.0.2
         imagePullPolicy: Always
         resources:
           requests:
-            memory: "16M"
-            cpu: "1m"
+            memory: "48M"
+            cpu: "5m"
           limits:
             memory: "1024M"
             cpu: "1000m"
@@ -31,12 +31,12 @@ spec:
         - name: KEYCLOAK_ADMIN_RIGHTS_USER_NAME
           valueFrom:
             secretKeyRef:
-              name: kommonitor-processing-engine
+              name: kommonitor-processing-scheduler
               key: admin.username
         - name: KEYCLOAK_ADMIN_RIGHTS_USER_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: kommonitor-processing-engine
+              name: kommonitor-processing-scheduler
               key: admin.password
         - name: KEYCLOAK_CLIENT_SECRET
           valueFrom:

--- a/components/kommonitor/processing-scheduler/secret.yaml
+++ b/components/kommonitor/processing-scheduler/secret.yaml
@@ -5,4 +5,5 @@ metadata:
 type: Opaque
 data:
   # Default values. Change it!
+  # Base64 encoded
   keycloak.secret: c2VjcmV0

--- a/components/kommonitor/spatial-data-processor/deployment.yaml
+++ b/components/kommonitor/spatial-data-processor/deployment.yaml
@@ -16,12 +16,12 @@ spec:
     spec:
       containers:
       - name: kommonitor-spatial-data-processor
-        image: kommonitor/spatial-data-processor
+        image: kommonitor/spatial-data-processor:1.0.4
         imagePullPolicy: Always
         resources:
           requests:
-            memory: "16M"
-            cpu: "1m"
+            memory: "128M"
+            cpu: "10m"
           limits:
             memory: "2048M"
             cpu: "1000m"

--- a/components/kommonitor/web-client/deployment.yaml
+++ b/components/kommonitor/web-client/deployment.yaml
@@ -16,11 +16,11 @@ spec:
     spec:
       containers:
       - name: kommonitor-web-client
-        image: kommonitor/web-client
+        image: kommonitor/web-client:3.1.4
         imagePullPolicy: Always
         resources:
           requests:
-            memory: "16M"
+            memory: "8M"
             cpu: "1m"
           limits:
             memory: "1024M"

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     cert-manager.io/issuer: kommonitor-issuer
+    cert-manager.io/common-name: demo.kommonitor.de
     nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
     nginx.ingress.kubernetes.io/proxy-body-size: "1G"
     nginx.ingress.kubernetes.io/rewrite-target: /$1
@@ -14,6 +15,7 @@ metadata:
       rewrite ^/$ /ui/ redirect;
   name: kommonitor
 spec:
+  # ingressClassName: nginx (or similar)
   tls:
   - hosts:
     - demo.kommonitor.de
@@ -69,5 +71,36 @@ spec:
         backend:
           service:
             name: kommonitor-web-client
+            port:
+              number: 80
+---
+# For non-nginx ingress:
+#
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/common-name: demo.kommonitor.de
+    # Use either cluster-issuer or issuer annotation
+    #
+    # cert-manager.io/cluster-issuer: default-issuer
+    cert-manager.io/issuer: kommonitor-issuer
+  name: kommonitor
+spec:
+  ingressClassName: cilium # traefik
+  tls:
+  - hosts:
+    - demo.kommonitor.de
+    secretName: kommonitor-tls
+  rules:
+  - host: demo.kommonitor.de
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: kommonitor-nginx
             port:
               number: 80

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -2,7 +2,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/ingress.class: "nginx"
+    # Use either cluster-issuer or issuer annotation
+    #
+    # cert-manager.io/cluster-issuer: default-issuer
     cert-manager.io/issuer: kommonitor-issuer
     cert-manager.io/common-name: demo.kommonitor.de
     nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
@@ -15,7 +17,7 @@ metadata:
       rewrite ^/$ /ui/ redirect;
   name: kommonitor
 spec:
-  # ingressClassName: nginx (or similar)
+  ingressClassName: nginx # (or similar)
   tls:
   - hosts:
     - demo.kommonitor.de


### PR DESCRIPTION
# Feature
- Add Ingress & Deployment [nginx-rewrite](./components/kommonitor/nginx-rewrite) for non-nginx ingress
- Pin image versions
# Fix
- Adjust pod resource specs
- processing-scheduler: wrong `secretKeyRef` in [deployment.yaml](./components/kommonitor/processing-scheduler/deployment.yaml)
# Doc 
- add base64 comment in `secret.yaml`
- add cert-manager (cluster-)issuer notice